### PR TITLE
Add case-insensitive keyword support, and add better golang multiline support

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
                 "scopeName": "inline-sql.injection",
                 "injectTo": [
                     "source.python",
-                    "source.go",
                     "source.java",
                     "source.ruby",
                     "source.cs",
@@ -105,6 +104,16 @@
                 "embeddedLanguages": {
                     "meta.embedded.sql": "sql",
                     "meta.template.expression.ts": "typescript"
+                }
+            },
+            {
+                "path": "./syntaxes/golang-multiline.json",
+                "scopeName": "golang-multiline.injection",
+                "injectTo": [
+                    "source.go"
+                ],
+                "embeddedLanguages": {
+                    "meta.embedded.sql": "sql"
                 }
             }
         ],

--- a/syntaxes/golang-multiline.json
+++ b/syntaxes/golang-multiline.json
@@ -1,0 +1,23 @@
+{
+    "scopeName": "golang-multiline.injection",
+    "fileTypes": [
+        "go"
+    ],
+    "injectionSelector": [
+        "L:string.quoted.raw.go -comment"
+    ],
+    "patterns": [
+        {
+            "name": "meta.embedded.sql",
+            "begin": "\\s*((?i)(select|with|insert|update|create table|create index)(?=\\s))|(--\\w+)",
+            "end": "(?=`)",
+            "beginCaptures": {
+            "2": { "name": "keyword.other.DML.sql" },
+            "3": { "name": "comment.line.double-dash.sql" }
+            },
+            "patterns": [
+                { "include": "source.sql" }
+            ]
+        }
+    ]
+}

--- a/syntaxes/highlight-sql-string.json
+++ b/syntaxes/highlight-sql-string.json
@@ -67,7 +67,7 @@
             ]
         },
         {
-            "begin": "(\")(SELECT |INSERT INTO |DELETE |UPDATE |CREATE TABLE |CREATE INDEX )",
+            "begin": "(?i)(\")(SELECT |INSERT INTO |DELETE |UPDATE |CREATE TABLE |CREATE INDEX )",
             "beginCaptures": {
                 "2": {
                     "name": "keyword.sql"
@@ -95,7 +95,7 @@
             ]
         },
         {
-            "begin": "(`)(SELECT |INSERT INTO |DELETE |UPDATE |CREATE TABLE |CREATE INDEX)",
+            "begin": "(?i)(`)(SELECT |INSERT INTO |DELETE |UPDATE |CREATE TABLE |CREATE INDEX)",
             "beginCaptures": {
                 "2": {
                     "name": "keyword.sql"
@@ -124,7 +124,7 @@
             ]
         },
         {
-            "begin": "(\"\"\")(SELECT |INSERT INTO |DELETE |UPDATE |CREATE TABLE |CREATE INDEX)",
+            "begin": "(?i)(\"\"\")(SELECT |INSERT INTO |DELETE |UPDATE |CREATE TABLE |CREATE INDEX)",
             "beginCaptures": {
                 "2": {
                     "name": "keyword.sql"

--- a/syntaxes/highlight-sql-string.json
+++ b/syntaxes/highlight-sql-string.json
@@ -2,7 +2,6 @@
     "scopeName": "inline-sql.injection",
     "fileTypes": [
         "py",
-        "go",
         "js",
         "jsx",
         "ts",

--- a/test/testdata/multiline.go
+++ b/test/testdata/multiline.go
@@ -12,8 +12,8 @@ select * from book where id = 34;
 `
 
 	notQuery := `
-SELECT This is not a query and should not be considered
-as one as --sql comment is not present.
+SELECT This a query and should be considered
+as one even though --sql comment is not present.
 Also, I hate manual testing.;
 `
 
@@ -32,7 +32,17 @@ select * from book where id = 34;
 
 	more5 := `SELECT * from book;`
 
-	print(query, another, more, notQuery, more2, more3, more4, more5)
+	more6 := `
+		SELECT * from book;
+	`
+
+	more7 := `
+		with hihi as (
+
+		)
+	`
+
+	print(query, another, more, notQuery, more2, more3, more4, more5, more6, more7)
 }
 
 func add(a, b int) int {

--- a/test/testdata/multiline.go
+++ b/test/testdata/multiline.go
@@ -28,7 +28,11 @@ select * from book where id = 34;
 
 	more3 := `--sql; select * from book;`
 
-	print(query, another, more, notQuery, more2, more3)
+	more4 := `select * from book;`
+
+	more5 := `SELECT * from book;`
+
+	print(query, another, more, notQuery, more2, more3, more4, more5)
 }
 
 func add(a, b int) int {

--- a/test/testdata/multiline.go
+++ b/test/testdata/multiline.go
@@ -17,6 +17,12 @@ as one even though --sql comment is not present.
 Also, I hate manual testing.;
 `
 
+	notQuery2 := `
+		this is really not a query, but we do demonstrate the only known issue
+		with this approach, where an in-string sql keyword will make the sql injection
+		mis-fire.
+	`
+
 	more := `--sql
 	select * from book where id = 34;
 `
@@ -42,7 +48,7 @@ select * from book where id = 34;
 		)
 	`
 
-	print(query, another, more, notQuery, more2, more3, more4, more5, more6, more7)
+	print(query, another, more, notQuery, notQuery2, more2, more3, more4, more5, more6, more7)
 }
 
 func add(a, b int) int {


### PR DESCRIPTION
Two things in here (i can split them if you like)
1) normal multi-language keyword detections are now case-insensitive.
2) Golang injection reworked with a strategy I've used for Python in the past: detect sql keywords inside a string context instead of detecting stringstart+sqlkeyword in source context. This allows matching of constructs like

```golang
sql := `
select from hihi
`
```

screenshot from your multiline.go example with my changes:

![image](https://user-images.githubusercontent.com/113399675/196060556-6c78d39b-830c-4702-b92c-eec3496c38d2.png)
