### PR TITLE
Fix: Golang didn't support MariaDB SQL comment syntax

### DIFF
--- a/syntaxes/golang-multiline.json
+++ b/syntaxes/golang-multiline.json
@@ -9,7 +9,7 @@
     "patterns": [
         {
             "name": "meta.embedded.sql",
-            "begin": "\\s*((?i)(select|with|insert|update|create table|create index)(?=\\s))|(--\\w+)",
+            "begin": "\\s*((?i)(select|with|insert|update|create table|create index)(?=\\s))|(--\\s*sql)",
             "end": "(?=`)",
             "beginCaptures": {
             "2": { "name": "keyword.other.DML.sql" },


### PR DESCRIPTION
Hi.
```
value := `--anything
testing 123
`
```

was being seen as SQL, whereas:
```
value := `-- sql
testing 123
`
```

wasn't being seen as SQL. It was missing the whitespace support that Lua has.
MariaDB requires a whitespace after the --.