### PR TITLE
Add configuration to disable linting

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,8 @@ Integration with real database is available and controlled through VSCode option
     "inlineSQL.dbHost": "localhost",
     "inlineSQL.dbPort": 5432,
     "inlineSQL.dbUser": "postgres",
-    "inlineSQL.dbPassword": "postgres"
+    "inlineSQL.dbPassword": "postgres",
+    "inlineSQL.lint": true
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -165,6 +165,11 @@
                     "default": "postgres",
                     "markdownDescription": "Database password."
                 },
+                "inlineSQL.lint": {
+                    "type": "boolean",
+                    "default": true,
+                    "markdownDescription": "Disable lint, use only syntax highlighting."
+                },
                 "inlineSQL.lintSQLFiles": {
                     "type": "boolean",
                     "default": false,

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -15,6 +15,7 @@ export type Configuration = {
     dbUser: string;
     dbPassword: string;
     lintSQLFiles: boolean;
+    lint: boolean;
 };
 
 export function getConfiguration() {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,6 +12,10 @@ async function checkRange(
 ): Promise<vscode.Diagnostic[]> {
     const diagnostics: vscode.Diagnostic[] = [];
 
+    if (!configuration.get('lint')) {
+        return diagnostics;
+    }
+
     const sqlStr = doc.getText(range);
 
     let errors = null;


### PR DESCRIPTION
This will allow to use syntax highlighting, without linting.

Linting don't work very well in all projects and for all queries. For example if there is multiple statements in the query, like
DDL query
```sql
create table table_a (
 name text not null
);

create table table_b (
 not_name text not null
);
```

Or when you want to use database which has different database name than the username, (limited by `sql-lint` module).

But the highlighting is working well, so be able to use at least the syntax highlighting when linting is not working, may be very useful for some users.

