### PR TITLE
feat: Support raw strings in Rust

### DIFF
--- a/test/testdata/multiline.rs
+++ b/test/testdata/multiline.rs
@@ -4,4 +4,5 @@ select * from book;
 "#;
 
     let _another = r#"--sql; select * from book;"#;
+    let _another = r##"--sql; select * from "book";"##;
 }


### PR DESCRIPTION
Add support for raw strings in Rust `let sql = r#"--sql ..."#;`
Also added support to get the end index when the sql ends on the same line